### PR TITLE
Cross-compiling for ARM & various other bits

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,33 @@
+snap7 (1.4.2-1yakkety) yakkety; urgency=medium
+
+  * build for yakkety
+
+ -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 06 Feb 2017 10:15:04 +0200
+
+snap7 (1.4.2-1xenial) xenial; urgency=medium
+
+  * build for xenial
+
+ -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 06 Feb 2017 10:14:29 +0200
+
+snap7 (1.4.2-1trusty) trusty; urgency=medium
+
+  * build for trusty
+
+ -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 06 Feb 2017 10:13:44 +0200
+
+snap7 (1.4.2-1precise) precise; urgency=medium
+
+  * new upstream release
+
+ -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 06 Feb 2017 10:09:59 +0200
+
+snap7 (1.4.0-0vivid) vivid; urgency=medium
+
+  * upload for vivid
+
+ -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Sat, 29 Aug 2015 14:19:46 +0200
+
 snap7 (1.4.0-0trusty) trusty; urgency=medium
 
   * new upstream release

--- a/control
+++ b/control
@@ -2,7 +2,7 @@ Source: snap7
 Priority: extra
 Maintainer: Gijs Molenaar <gijs@pythonic.nl>
 Build-Depends: debhelper (>= 8.0.0)
-Standards-Version: 3.9.4
+Standards-Version: 3.9.5
 Section: libs
 Homepage: http://snap7.sourceforge.net/
 Vcs-Git: git://github.com/gijzelaerr/snap7-debian.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/gijzelaerr/snap7-debian
 Package: libsnap7-dev
 Section: libdevel
 Architecture: any
-Depends: libsnap71 (= ${binary:Version})
+Depends: libsnap71 (= ${binary:Version}), ${misc:Depends}
 Description: communication suite for interfacing with Siemens S7 PLCs
  The new CPUs 1200/1500 and SINAMICS Drives are also partially supported.
  Although it has been designed to overcome the limitations of OPC servers when

--- a/copyright
+++ b/copyright
@@ -1,17 +1,16 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: snap7
-Source: <url://example.com>
+Source: https://sourceforge.net/projects/snap7/
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: LGPL-3.0+
+Copyright: 2012-2017 Davide Nardella <software@masmec.com>
+License: LGPL-3.0
 
 Files: debian/*
 Copyright: 2013 Gijs Molenaar <gijs@pythonic.nl>
 License: LGPL-3.0+
 
-License: LGPL-3.0+
+License: LGPL-3.0
  This package is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
@@ -27,8 +26,3 @@ License: LGPL-3.0+
  .
  On Debian systems, the complete text of the GNU Lesser General
  Public License can be found in "/usr/share/common-licenses/LGPL-3".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid to pick license terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/rules
+++ b/rules
@@ -16,8 +16,15 @@ endif
 	dh $@ 
 
 override_dh_auto_build:
-	cd build/unix; make -f $(DEB_HOST_GNU_CPU)_linux.mk all
+	cd build/unix; make -f $(DEB_HOST_GNU_CPU)_linux.mk all			\
+		CXX=$(DEB_HOST_GNU_TYPE)-g++					\
+		LinkerName=$(DEB_HOST_GNU_TYPE)-g++				\
+		SharedObjectLinkerName="$(DEB_HOST_GNU_TYPE)-g++ -shared -fPIC"
 	mv build/bin/$(DEB_HOST_GNU_CPU)-linux/libsnap7.so build/bin/$(DEB_HOST_GNU_CPU)-linux/libsnap7.so.1
+
+override_dh_shlibdeps:
+	dh_shlibdeps -l/lib/$(DEB_HOST_GNU_TYPE):/usr/$(DEB_HOST_GNU_TYPE)/lib	\
+		$@ -- -xlibgcc1-armhf-cross
 
 override_dh_auto_clean:
 	rm -f build/bin/$(DEB_HOST_GNU_CPU)-linux/libsnap7.so

--- a/rules
+++ b/rules
@@ -8,6 +8,8 @@ DEB_HOST_GNU_CPU ?= $(shell dpkg-architecture -qDEB_HOST_GNU_CPU)
 
 ifeq ($(DEB_HOST_GNU_CPU),i686)
 	DEB_HOST_GNU_CPU = i386
+else ifeq ($(DEB_HOST_GNU_CPU),arm)
+	DEB_HOST_GNU_CPU = arm_v6
 endif
 
 %:


### PR DESCRIPTION
The package won't build on ARM because either of arm_v6 or arm_v7 needs to be selected. I chose arm_v6 as baseline to also support the RaspberryPi 1. Moreover I've added support for cross-compiling and filled in or corrected a few fields in the copyright file.

Your GitHub repo is missing a few changes that are present in your latest Debian source tarball because you haven't pushed in a while. I've included a commit which contains these changes but alternatively feel free to push them and I'll rebase this pull.

If you're not happy with any of these changes just let me know or close the pull without merging. I'm merely submitting this in case it's of use to you or someone else. Thanks!